### PR TITLE
Fix copy/paste bug when assigning slider values

### DIFF
--- a/DirectInput Device Plugin.cs
+++ b/DirectInput Device Plugin.cs
@@ -177,23 +177,23 @@ namespace DirectInput_Device
                 if (sliders.Count() > 0)
                     deviceWrapper.Slider1.Value = sliders[0] / 65535f;
                 if (sliders.Count() > 1)
-                    deviceWrapper.Slider1.Value = sliders[1] / 65535f;
+                    deviceWrapper.Slider2.Value = sliders[1] / 65535f;
                 if (sliders.Count() > 2)
-                    deviceWrapper.Slider1.Value = sliders[2] / 65535f;
+                    deviceWrapper.Slider3.Value = sliders[2] / 65535f;
                 if (sliders.Count() > 3)
-                    deviceWrapper.Slider1.Value = sliders[3] / 65535f;
+                    deviceWrapper.Slider4.Value = sliders[3] / 65535f;
                 if (sliders.Count() > 4)
-                    deviceWrapper.Slider1.Value = sliders[4] / 65535f;
+                    deviceWrapper.Slider5.Value = sliders[4] / 65535f;
                 if (sliders.Count() > 5)
-                    deviceWrapper.Slider1.Value = sliders[5] / 65535f;
+                    deviceWrapper.Slider6.Value = sliders[5] / 65535f;
                 if (sliders.Count() > 6)
-                    deviceWrapper.Slider1.Value = sliders[6] / 65535f;
+                    deviceWrapper.Slider7.Value = sliders[6] / 65535f;
                 if (sliders.Count() > 7)
-                    deviceWrapper.Slider1.Value = sliders[7] / 65535f;
+                    deviceWrapper.Slider8.Value = sliders[7] / 65535f;
                 if (sliders.Count() > 8)
-                    deviceWrapper.Slider1.Value = sliders[8] / 65535f;
+                    deviceWrapper.Slider9.Value = sliders[8] / 65535f;
                 if (sliders.Count() > 9)
-                    deviceWrapper.Slider1.Value = sliders[9] / 65535f;
+                    deviceWrapper.Slider10.Value = sliders[9] / 65535f;
             }
         }
 


### PR DESCRIPTION
Fix copy/paste bug when assigning slider values to
device wrapper. Instead of assigning multiple sliders to
subsequent fields of `deviceWrapper`, always the same field
Slider1 was used.
Now, fields `Slider1` ... `Slider10` are used as intended.
This should fix (multiple) sliders of DirectInput Joysticks.

When trying to use a Microsoft Sidewinder Precision 2
joystick with InputMapper 1.7, I got everything to work but
the acceleration control, which is reported as a slider.
I stumbled upon this code, not sure whether it is the code
working in IM 1.7 (it seems quite old and says something
about IM 2), but thought I could give it a try.
I wasn't able to build the plugin with this fix (not a C#
developer), but would be glad to test with my joystick.